### PR TITLE
fixed parsing error due to missing comma.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "repository" : { 
         "type" : "git",
          "url" : "https://github.com/adobe/brackets-phonegap.git"
-    }
+    },
     "engines": {
         "brackets": ">=0.30.0"
     }


### PR DESCRIPTION
parsing error: missing comma before "engines"
